### PR TITLE
feat(lib, config): 增加不安全的下载方式 & 优化 lib.sh:download 逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ http-meta 子菜单:
 | `drop_priv_method` | shell 用户降权方式：<br> `su`：启动前经 `su 2000` 切换（KSU/APatch 推荐）；<br> `node`：Node preload 自降权（KSU/APatch 经 `su 0 -c` 启动；Magisk 推荐） |
 | `run_http_meta` | 是否运行 http-meta `true`(默认)/`false` |
 | `run_http_meta_with_inet` | http-meta 是否授予 `inet` 组（仅 `shell` 用户生效）：<br> `false`(默认) 流量直连不走 VPN；<br> `true` 可用系统 DNS 但流量走 VPN |
+| `allow_nosafe_download` | 是否允许不安全的下载方式 `true`/`false`(默认) : 用于更新时在所有下载方式不可用时降级使用 root 环境提供的 `busybox wget` 下载 (可能存在安全风险) |
 
 ## 手动操作
 

--- a/module/scripts/lib.sh
+++ b/module/scripts/lib.sh
@@ -262,14 +262,54 @@ backup_env_file() {
 
 # ---------- 下载: curl 优先, 回退 wget ----------
 download() {  # $1=url  $2=输出文件路径
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL --connect-timeout 10 --max-time 600 --retry 3 --retry-delay 2 --retry-max-time 60 "$1" -o "$2"
-  elif command -v wget >/dev/null 2>&1; then
-    wget -q -O "$2" "$1"
-  else
-    err "未找到 curl / wget, 无法下载"
-    return 127
+  local use_downloader=""
+  local busybox_path=""
+  local candidate=""
+
+  if command -v curl >/dev/null 2>&1; then # curl
+    use_downloader="curl"
+  elif command -v wget >/dev/null 2>&1; then # wget
+    use_downloader="wget"
+  elif [ "$allow_nosafe_download" = "true" ]; then # busybox
+    busybox_path=$(command -v busybox 2>/dev/null || true)
+    if [ -z "$busybox_path" ]; then
+      for candidate in "/data/adb/magisk/busybox" "/data/adb/ksu/bin/busybox" "/data/adb/ap/bin/busybox"; do
+        if [ -x "$candidate" ]; then
+          busybox_path="$candidate"
+          break
+        fi
+      done
+    fi
+    if [ -n "$busybox_path" ] && "$busybox_path" --list 2>/dev/null | grep -q "^wget$"; then
+      use_downloader="busybox"
+    else
+      use_downloader="none"
+    fi
+  else # none
+    use_downloader="none"
   fi
+
+  case "$use_downloader" in
+    curl)
+      curl -fsSL --connect-timeout 10 --max-time 600 --retry 3 --retry-delay 2 --retry-max-time 60 "$1" -o "$2"
+      ;;
+    wget)
+      wget -q -O "$2" "$1"
+      ;;
+    busybox)
+      warn "使用 busybox wget 下载, 可能存在安全风险"
+      "$busybox_path" wget -q -O "$2" "$1" >/dev/null 2>&1
+      ;;
+    *)
+      err "未找到可用的下载方式"
+      if [ "$allow_nosafe_download" = "true" ]; then
+        err "allow_nosafe_download 已启用, 但未找到包含 wget 的 busybox"
+      else
+        warn "如果您接受可能存在的安全风险, 可在 config: allow_nosafe_download 中设置为 true 以使用不安全的下载方式"
+      fi
+      return 127
+      ;;
+  esac
 }
 
 # ---------- 抓取文本 (版本号 / API) ----------

--- a/module/scripts/sub_store.config
+++ b/module/scripts/sub_store.config
@@ -40,3 +40,7 @@ run_http_meta="true"
 # 给 http-meta 进程额外授予 inet 组权限, 以便在 Android 上使用系统 DNS (getaddrinfo)
 # 但会导致 http-meta 进程流量经过 VPN，默认关闭
 run_http_meta_with_inet="false"
+
+# ---------- 下载选项 ----------
+# 是否允许使用不安全的下载方式
+allow_nosafe_download="false"


### PR DESCRIPTION
当 lib:download curl,wget 方法不可用, 且 config `allow_nosafe_download` 为 `true` 时, 使用 root 环境提供的 `busybox wget` 来进行下载

优化 lib:download, 改为 case 方便后续扩展