### PR TITLE
feat(config): 新增兼容模式选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ http-meta 子菜单:
 | `run_http_meta` | 是否运行 http-meta `true`(默认)/`false` |
 | `run_http_meta_with_inet` | http-meta 是否授予 `inet` 组（仅 `shell` 用户生效）：<br> `false`(默认) 流量直连不走 VPN；<br> `true` 可用系统 DNS 但流量走 VPN |
 | `allow_nosafe_download` | 是否允许不安全的下载方式 `true`/`false`(默认) : 用于更新时在所有下载方式不可用时降级使用 root 环境提供的 `busybox wget` 下载 (可能存在安全风险) |
+| `enable_legacy_support` | 兼容模式 `false`/`true`/`backendport_backendpath`： 为基于 Sub Store for Magisk (xream) 模块的第三方工具提供兼容 <br> `false` 关闭<br> `true` 开启<br> `backendport_backendpath` 将后端路径拼接到后端端口以兼容部分工具读取 |
+
 
 ## 手动操作
 

--- a/module/scripts/sub_store.config
+++ b/module/scripts/sub_store.config
@@ -44,3 +44,17 @@ run_http_meta_with_inet="false"
 # ---------- 下载选项 ----------
 # 是否允许使用不安全的下载方式
 allow_nosafe_download="false"
+
+# ---------- 兼容模式 ----------
+# 为基于 Sub Store for Magisk (xream) 模块的第三方工具提供兼容
+# 开启时会在 service start/stop 时 创建/删除 /data/adb/sub_store/scripts/sub_store.config 文件
+#
+# false
+# - 关闭兼容模式
+# true
+# - 正常兼容模式
+# backendport_backendpath
+# - 将后端路径拼接到后端端口以兼容部分工具读取
+# - SUB_STORE_BACKEND_API_HOST/SUB_STORE_FRONTEND_BACKEND_PATH
+# - 以兼容部分工具未使用 SUB_STORE_FRONTEND_BACKEND_PATH 的情况
+enable_legacy_support="false"

--- a/module/scripts/sub_store.service
+++ b/module/scripts/sub_store.service
@@ -181,6 +181,51 @@ start_bin() {
     fi
   fi
 
+  if [ "${enable_legacy_support:-false}" != "false" ]; then
+      legacy_config_dir="/data/adb/sub_store"
+      legacy_config_file="${legacy_config_dir}/scripts/sub_store.config"
+
+      legacy_config_preload="# 这是 Sub-Store for Android 为基于 Sub Store for Magisk (xream) 模块的第三方工具向下兼容的配置文件\n# 此不是运行时配置, 如需修改配置, 请编辑 ${CONFIG_DIR}/sub_store.config\n# enable_legacy_support: ${enable_legacy_support}\n"
+      backend_host="${SUB_STORE_BACKEND_API_HOST:-127.0.0.1}"
+      backend_path="${SUB_STORE_FRONTEND_BACKEND_PATH}"
+
+      case "$enable_legacy_support" in
+          true)
+              backend_port="${SUB_STORE_BACKEND_API_PORT:-3001}"
+              ;;
+          backendport_backendpath)
+              backend_port="${SUB_STORE_BACKEND_API_PORT:-3001}/${backend_path##/}"
+              ;;
+          *)
+              log Warn "未知的 enable_legacy_support 值: $enable_legacy_support, fallback to true"
+              backend_port="${SUB_STORE_BACKEND_API_PORT:-3001}"
+              ;;
+      esac
+
+      if [ "${SUB_STORE_BACKEND_MERGE:-false}" = "true" ]; then
+          frontend_host="$backend_host"
+          frontend_port="${SUB_STORE_BACKEND_API_PORT:-3002}"
+      else
+          frontend_host="${SUB_STORE_FRONTEND_API_HOST:-127.0.0.1}"
+          frontend_port="${SUB_STORE_FRONTEND_API_PORT:-3002}"
+      fi
+
+      legacy_config_preload="${legacy_config_preload}\nsub_store_backend_merge=${SUB_STORE_BACKEND_MERGE:-false}"
+      legacy_config_preload="${legacy_config_preload}\nsub_store_backend_host=\"${backend_host}\""
+      legacy_config_preload="${legacy_config_preload}\nsub_store_backend_port=\"${backend_port}\""
+      legacy_config_preload="${legacy_config_preload}\nsub_store_frontend_host=\"${frontend_host}\""
+      legacy_config_preload="${legacy_config_preload}\nsub_store_frontend_port=\"${frontend_port}\""
+      legacy_config_preload="${legacy_config_preload}\nsub_store_frontend_backend_path=\"${backend_path}\""
+      legacy_config_preload="${legacy_config_preload}\nhttp_meta_host=\"${HOST:-127.0.0.1}\""
+      legacy_config_preload="${legacy_config_preload}\nhttp_meta_port=\"${PORT:-9876}\""
+
+      mkdir -p "$legacy_config_dir/scripts"
+      echo "$legacy_config_preload" > "$legacy_config_file"
+      chown -R 0:0 "$legacy_config_dir"
+      chmod -R 0600 "$legacy_config_dir"
+      log Info "向下兼容模式已启用: ${enable_legacy_support}"
+  fi
+
   # 记录本次启动时间 (写入内容 + 更新 mtime), 用于配置修改提醒
   date '+%Y-%m-%d %H:%M:%S' > "$run_path/.start_marker" 2>/dev/null
 
@@ -199,6 +244,12 @@ stop_service() {
   [ -n "$_pids" ] && kill -15 $_pids 2>/dev/null
   _pids="$(pidof "$bin_name" 2>/dev/null) $(pidof http-meta 2>/dev/null)"
   [ -n "$_pids" ] && kill -9 $_pids 2>/dev/null
+
+  # legacy config
+  if [ "${enable_legacy_support:-false}" != "false" ] && [ -d "/data/adb/sub_store" ]; then
+    rm -rf "/data/adb/sub_store"
+  fi
+
   return 0
 }
 

--- a/module/uninstall.sh
+++ b/module/uninstall.sh
@@ -20,5 +20,10 @@ kill -15 $(pidof sub_store_node http-meta) 2>/dev/null
 sleep 1
 kill -9 $(pidof sub_store_node http-meta) 2>/dev/null
 
+# legacy config
+if [ -d "/data/adb/sub_store" ]; then
+  rm -rf "/data/adb/sub_store"
+fi
+
 echo "- Sub-Store 服务已停止"
 echo "- 数据保留在 /data/local/sub_store (如需彻底删除请手动删除)"


### PR DESCRIPTION
为基于 Sub Store for Magisk (xream) 模块的第三方工具提供兼容
开启时会在 service start/stop 时 创建/删除 /data/adb/sub_store/scripts/sub_store.config 文件

---

`false`关闭兼容模式
`true` 正常兼容模式
`backendport_backendpath` 将 SUB_STORE_FRONTEND_BACKEND_PATH 拼接到 SUB_STORE_BACKEND_API_HOST